### PR TITLE
Implement GitHub oauth

### DIFF
--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -37,7 +37,12 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 
 					const session = await credentials.getSession();
 
-					vscode.window.showInformationMessage("Signed In as: '" + session.account.label + "'");
+					if (session) {
+						vscode.window.showInformationMessage("Signed In as: '" + session.account.label + "'");
+					}
+					else {
+						// Do nothing
+					}
 
 					if(this.ext_uri){
 						HomePanel.createOrShow(this.ext_uri, {}); //create a Homepanel window on sign in

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { Credentials } from "./authentication";
 import { getNonce } from "./getNonce";
 import { HomePanel } from './HomePanel';
 
@@ -6,9 +7,11 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 	_view?: vscode.WebviewView;
 	_doc?: vscode.TextDocument;
 	ext_uri?: vscode.Uri;
+	context: vscode.ExtensionContext;
 
-	constructor(private readonly _extensionUri: vscode.Uri) { 
+	constructor(private readonly _extensionUri: vscode.Uri, currentContext: vscode.ExtensionContext) { 
 		this.ext_uri = _extensionUri;
+		this.context = currentContext;
 	}
 
 	public resolveWebviewView(webviewView: vscode.WebviewView) {
@@ -29,9 +32,13 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 					if (!data.value) {
 						return;
 					}
-					/**
-					 * TODO: GitHub OAuth configuration
-					 */
+					const credentials = new Credentials();
+					await credentials.initialize(this.context);
+
+					const session = await credentials.getSession();
+
+					vscode.window.showInformationMessage("Signed In as: '" + session.account.label + "'");
+
 					if(this.ext_uri){
 						HomePanel.createOrShow(this.ext_uri, {}); //create a Homepanel window on sign in
 					}

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -1,0 +1,56 @@
+import * as vscode from 'vscode';
+
+const GITHUB_AUTH_PROVIDER_ID = 'github';
+// The GitHub Authentication Provider accepts the scopes described here:
+// https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/
+const SCOPES = ['user', 'public_repo', 'write:org'];
+
+export class Credentials {
+	private session: vscode.AuthenticationSession | undefined;
+
+	async initialize(context: vscode.ExtensionContext): Promise<void> {
+		this.registerListeners(context);
+		this.setSession();
+	}
+
+	private async setSession() {
+		/**
+		 * By passing the `createIfNone` flag, a numbered badge will show up on the accounts activity bar icon.
+		 * An entry for the sample extension will be added under the menu to sign in. This allows quietly 
+		 * prompting the user to sign in.
+		 * */
+		const session = await vscode.authentication.getSession(GITHUB_AUTH_PROVIDER_ID, SCOPES, { createIfNone: false });
+
+		if (this.session) {            
+			this.session = session;
+            return this.session;
+		}
+		
+		this.session = undefined;
+	}
+
+	registerListeners(context: vscode.ExtensionContext): void {
+		/**
+		 * Sessions are changed when a user logs in or logs out.
+		 */
+		context.subscriptions.push(vscode.authentication.onDidChangeSessions(async e => {
+			if (e.provider.id === GITHUB_AUTH_PROVIDER_ID) {
+				await this.setSession();
+			}
+		}));
+	}
+
+	async getSession(): Promise<vscode.AuthenticationSession> {
+		if (this.session) {
+			return this.session;
+		}
+
+		/**
+		 * When the `createIfNone` flag is passed, a modal dialog will be shown asking the user to sign in.
+		 * Note that this can throw if the user clicks cancel.
+		 */
+		this.session = await vscode.authentication.getSession(GITHUB_AUTH_PROVIDER_ID, SCOPES, { createIfNone: true });
+
+		return this.session;
+	}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { SidebarProvider } from './SidebarProvider';
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-	const sidebarProvider = new SidebarProvider(context.extensionUri);
+	const sidebarProvider = new SidebarProvider(context.extensionUri, context);
 	context.subscriptions.push(
 		vscode.window.registerWebviewViewProvider(
 			"proj-sidebar",


### PR DESCRIPTION
Turns out, it's pretty easy to implement - without any backend confusing stuff.
(VSCode has its own APIs we can call: `vscode.authentication.getSession()`)