### PR TITLE
GitHub oauth improvement

### DIFF
--- a/webviews/components/Sidebar.svelte
+++ b/webviews/components/Sidebar.svelte
@@ -8,6 +8,8 @@
         session = message.payload.session;
     }
   });
+  // send message as soon as sidebar loads.
+  ext_vscode.postMessage({ type: "onSignIn", value: "success" });
 </script>
 
 {#if !session}
@@ -26,7 +28,7 @@
   <button
     on:click={() => {
       //send message to SidebarProvider.ts
-      ext_vscode.postMessage({ type: "onSignIn", value: "success" });
+      ext_vscode.postMessage({ type: "onSignIn", value: "noNotification" });
     }}
   >
     See Projects


### PR DESCRIPTION
This is just a small hack to get session everytime the sidebar is loaded. Since we get session as soon as extension loads up, this is just a double check if things are working fine everytime we load the sidebar.
(Also, stop sending so many annoying notifications everytime one clicks on `See Projects`)